### PR TITLE
Remove MemoryStore.observe() fake onChange notification

### DIFF
--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -1,4 +1,3 @@
-import 'setimmediate';
 import _ from 'lodash';
 import fetch from 'isomorphic-fetch';
 import url from 'url';

--- a/lib/MemoryStore/index.js
+++ b/lib/MemoryStore/index.js
@@ -1,4 +1,3 @@
-import 'setimmediate';
 import _ from 'lodash';
 
 import Store from '../Store';
@@ -117,10 +116,8 @@ class MemoryStore extends Store {
   observe(query, onChange) {
     const path = this.toPath(query);
     const { observers } = this._findOrCreatePathData(path);
-    const firstTick = setImmediate(() => onChange(this.readFromState(query)));
-    const observer = [onChange, firstTick];
-    observers.add(observer);
-    return () => this._unobserve(path, observer);
+    observers.add(onChange);
+    return () => this._unobserve(path, onChange);
   }
 
   /**
@@ -128,12 +125,10 @@ class MemoryStore extends Store {
    *
    * @private
    * @param {String} path Path that will be used to match the observer.
-   * @param {Object} observer Observer to remove.
+   * @param {Function} observer Observer function to remove.
    * @return {MemoryStore} Instance of the current MemoryStore.
    */
   _unobserve(path, observer) {
-    const [, firstTick] = observer;
-    clearImmediate(firstTick);
     if(this.data.has(path)) {
       const pathData = this.data.get(path);
       pathData.observers.delete(observer);
@@ -156,7 +151,7 @@ class MemoryStore extends Store {
   _set(path, state) {
     const data = this._findOrCreatePathData(path);
     data.state = state;
-    data.observers.forEach(([onChange]) => onChange(state));
+    data.observers.forEach((observer) => observer(state));
   }
 
   /**
@@ -190,8 +185,7 @@ class MemoryStore extends Store {
     const data = this.data.get(path);
     const state = Store.State.reject(data.store.value, 'Store deleted', { path });
     data.observers.forEach((observer) => {
-      const [onChange] = observer;
-      onChange(state);
+      observer(state);
       this._unobserve(path, observer);
     });
     data.observers.clear();

--- a/lib/stores.js
+++ b/lib/stores.js
@@ -72,15 +72,16 @@ function stores(
       const { props, context } = this;
       const flux = context[fluxKey];
       const bindings = getBindings(props, flux);
-      _.each(bindings, (binding, key) =>
+      _.each(bindings, (binding, key) => {
+        this.updateStoreState(key, flux.readStoreFromState(binding));
         this.observers.set(
           key,
           flux.observeStore(
             binding,
             (state) => this.updateStoreState(key, state),
           ),
-        )
-      );
+        );
+      });
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.0.0",
     "path-to-regexp": "^1.2.1",
-    "setimmediate": "^1.0.4",
     "prop-types": "^15.6.0",
     "shallowequal": "^1.0.2"
   },


### PR DESCRIPTION
Now MemoryStore.observe() doesn't call back right away, following
HTTPStore behavior.

The fact that this was done using setImmediate() did not play well with
user jest/jsdom testing: the call back would be executed after the test
ended, after environment teardown. Which at best was just executing code
for nothing and at worst in case of a thrown exception would break the
test run (endless waiting loop).

Replace this with an explicit, synchronous state setting at observe()
call site: in componentDidMount() of Store wrapper component, as it was
already done in componentWillReceiveProps(). This maintains previous
behavior but stays in the confines of React lifecycle functions.
It doesn't change the fact that two render() may still be performed
in sequence, due to state setting triggered after first render().

Remove setimmediate dep because it became unused.