### PR TITLE
[Fix] Fix state desync in HTTPStore

### DIFF
--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -182,10 +182,10 @@ class HTTPStore extends Store {
    */
   observe(query, onChange) {
     const path = this.toPath(query);
-    const { observers, state } = this._findOrCreatePathData(path);
-    observers.add(onChange);
-    if(state.isRejected()) {
-      this._forceFetch(path, query);
+    const data = this._findOrCreatePathData(path);
+    data.observers.add(onChange);
+    if(data.state.isRejected()) {
+      data.promise = this._forceFetch(path, query);
     }
     return () => this._unobserve(path, onChange);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nexus",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Real world apps with React",
   "main": "dist/node/prod/lib/index.js",
   "browser": "dist/browser/prod/lib/index.js",


### PR DESCRIPTION
In order for `fetch` to be awaitable, the `forceFetch` promise must be
up to date. This wasn't the case before this commit: `observe` triggered
a `forceFetch` without sharing its promise. In this case, `fetch`
couldn't return the `forceFetch` promise which resulted in desync: the
store state was "pending" but `fetch` didn't return a promise.

Fixes this by saving the `forceFetch` promise in `observe` (the same way
it was already done in `fetch`).
